### PR TITLE
Fix - avoid running tests on merged content unrelated to current branche changes

### DIFF
--- a/lib/quick_check/cli.rb
+++ b/lib/quick_check/cli.rb
@@ -137,9 +137,26 @@ module QuickCheck
       if @options[:include_committed_diff]
         current_branch = git_current_branch
         if current_branch && base_branch && current_branch != base_branch
-          # Include files changed on this branch vs base
-          range = diff_range_against_base(base_branch)
-          files.concat(git_diff_name_only(["--name-only", "-M", "-C", "--diff-filter=ACMR", range])) if range
+          # Prefer comparing against upstream tracking branch if it exists and has differences.
+          # This correctly handles rebases by only showing changes unique to the local branch,
+          # not changes that came from the base branch during the rebase.
+          upstream_branch = git_upstream_branch(current_branch)
+          if upstream_branch
+            if upstream_has_differences?(upstream_branch)
+              # Compare local branch against its remote tracking branch
+              # Use --first-parent to exclude changes from merge commits
+              changed_files = diff_range_against_upstream(upstream_branch)
+              files.concat(changed_files) if changed_files
+            end
+            # If upstream is in sync, don't include committed changes (only staged/unstaged)
+            # This avoids testing files that were already tested when the branch was pushed
+          else
+            # Fall back to comparing against base branch if no upstream exists.
+            # Use --first-parent to ensure we only get changes from commits directly on this branch,
+            # excluding changes from merge commits.
+            changed_files = diff_range_against_base(base_branch)
+            files.concat(changed_files) if changed_files
+          end
         end
       end
 
@@ -256,12 +273,52 @@ module QuickCheck
       ok ? out.to_s.strip : nil
     end
 
+    def git_upstream_branch(branch)
+      # Get the upstream tracking branch for the current branch
+      ok, out, _err = run_cmd(["git", "rev-parse", "--abbrev-ref", "--symbolic-full-name", "#{branch}@{u}"])
+      if ok && !out.to_s.strip.empty?
+        upstream = out.to_s.strip
+        # Verify the upstream branch actually exists
+        ok_check, _out_check, _err_check = run_cmd(["git", "rev-parse", "--verify", "--quiet", upstream])
+        return upstream if ok_check
+      end
+      nil
+    rescue StandardError
+      nil
+    end
+
+    def upstream_has_differences?(upstream)
+      # Check if there are any differences between HEAD and upstream
+      # This helps us decide whether to use upstream or fall back to base branch
+      ok, out, _err = run_cmd(["git", "rev-list", "--count", "#{upstream}..HEAD"])
+      return false unless ok
+      count = out.to_s.strip.to_i
+      count > 0
+    end
+
+    def diff_range_against_upstream(upstream)
+      # Use git log --first-parent to get only files changed in commits directly on this branch,
+      # excluding changes from merge commits. This correctly handles branches that have merged
+      # main into them by only showing changes unique to the branch's own commits.
+      files = git_log_first_parent_files(upstream, "HEAD")
+      files.empty? ? nil : files
+    end
+
     def diff_range_against_base(base)
-      # Use merge-base to find the common ancestor, which correctly handles
-      # rebases and merges by only showing changes unique to the current branch.
-      # This avoids including incoming changes from merges/rebases.
-      merge_base = find_merge_base(base)
-      merge_base ? "#{merge_base}...HEAD" : nil
+      # Use git log --first-parent to get only files changed in commits directly on this branch,
+      # excluding changes from merge commits. This correctly handles branches that have merged
+      # main into them by only showing changes unique to the branch's own commits.
+      base_ref = if local_branch_exists?(base)
+                   base
+                 elsif remote_branch_exists?(base)
+                   "origin/#{base}"
+                 else
+                   return nil
+                 end
+      
+      # Get files changed in first-parent commits only (excludes merge commits)
+      files = git_log_first_parent_files(base_ref, "HEAD")
+      files.empty? ? nil : files
     end
 
     def find_merge_base(base)
@@ -274,8 +331,22 @@ module QuickCheck
               return nil
             end
 
-      ok, out, _err = run_cmd(["git", "merge-base", ref, "HEAD"])
+      find_merge_base_for_refs(ref, "HEAD")
+    end
+
+    def find_merge_base_for_refs(ref1, ref2)
+      ok, out, _err = run_cmd(["git", "merge-base", ref1, ref2])
       ok ? out.to_s.strip : nil
+    end
+
+    def git_log_first_parent_files(base_ref, head_ref)
+      # Get files changed in first-parent commits only (excludes merge commits)
+      # This ensures we only get changes from commits directly on the branch
+      cmd = ["git", "log", "--first-parent", "--name-only", "--diff-filter=ACMR", "--format=", "#{base_ref}..#{head_ref}"]
+      ok, out, _err = run_cmd(cmd)
+      return [] unless ok
+      
+      out.split("\n").map(&:strip).reject(&:empty?).uniq
     end
 
     def git_diff_name_only(args)

--- a/lib/quick_check/cli.rb
+++ b/lib/quick_check/cli.rb
@@ -137,23 +137,13 @@ module QuickCheck
       if @options[:include_committed_diff]
         current_branch = git_current_branch
         if current_branch && base_branch && current_branch != base_branch
-          # Prefer comparing against upstream tracking branch if it exists and has differences.
-          # This correctly handles rebases by only showing changes unique to the local branch,
-          # not changes that came from the base branch during the rebase.
           upstream_branch = git_upstream_branch(current_branch)
-          if upstream_branch
-            if upstream_has_differences?(upstream_branch)
-              # Compare local branch against its remote tracking branch
-              # Use --first-parent to exclude changes from merge commits
-              changed_files = diff_range_against_upstream(upstream_branch)
-              files.concat(changed_files) if changed_files
-            end
-            # If upstream is in sync, don't include committed changes (only staged/unstaged)
-            # This avoids testing files that were already tested when the branch was pushed
-          else
-            # Fall back to comparing against base branch if no upstream exists.
-            # Use --first-parent to ensure we only get changes from commits directly on this branch,
-            # excluding changes from merge commits.
+          # Prefer upstream tracking branch to correctly handle rebases (only shows local changes)
+          if upstream_branch && upstream_has_differences?(upstream_branch)
+            changed_files = diff_range_against_upstream(upstream_branch)
+            files.concat(changed_files) if changed_files
+          elsif !upstream_branch
+            # Fall back to base branch if no upstream exists
             changed_files = diff_range_against_base(base_branch)
             files.concat(changed_files) if changed_files
           end
@@ -288,26 +278,18 @@ module QuickCheck
     end
 
     def upstream_has_differences?(upstream)
-      # Check if there are any differences between HEAD and upstream
-      # This helps us decide whether to use upstream or fall back to base branch
+      # Only use upstream if it has local commits (avoids testing already-pushed changes)
       ok, out, _err = run_cmd(["git", "rev-list", "--count", "#{upstream}..HEAD"])
       return false unless ok
-      count = out.to_s.strip.to_i
-      count > 0
+      out.to_s.strip.to_i > 0
     end
 
     def diff_range_against_upstream(upstream)
-      # Use git log --first-parent to get only files changed in commits directly on this branch,
-      # excluding changes from merge commits. This correctly handles branches that have merged
-      # main into them by only showing changes unique to the branch's own commits.
       files = git_log_first_parent_files(upstream, "HEAD")
       files.empty? ? nil : files
     end
 
     def diff_range_against_base(base)
-      # Use git log --first-parent to get only files changed in commits directly on this branch,
-      # excluding changes from merge commits. This correctly handles branches that have merged
-      # main into them by only showing changes unique to the branch's own commits.
       base_ref = if local_branch_exists?(base)
                    base
                  elsif remote_branch_exists?(base)
@@ -315,37 +297,15 @@ module QuickCheck
                  else
                    return nil
                  end
-      
-      # Get files changed in first-parent commits only (excludes merge commits)
       files = git_log_first_parent_files(base_ref, "HEAD")
       files.empty? ? nil : files
     end
 
-    def find_merge_base(base)
-      # Try local branch first, then remote
-      ref = if local_branch_exists?(base)
-              base
-            elsif remote_branch_exists?(base)
-              "origin/#{base}"
-            else
-              return nil
-            end
-
-      find_merge_base_for_refs(ref, "HEAD")
-    end
-
-    def find_merge_base_for_refs(ref1, ref2)
-      ok, out, _err = run_cmd(["git", "merge-base", ref1, ref2])
-      ok ? out.to_s.strip : nil
-    end
-
     def git_log_first_parent_files(base_ref, head_ref)
-      # Get files changed in first-parent commits only (excludes merge commits)
-      # This ensures we only get changes from commits directly on the branch
+      # Use --first-parent to exclude merge commits, only showing changes from direct branch commits
       cmd = ["git", "log", "--first-parent", "--name-only", "--diff-filter=ACMR", "--format=", "#{base_ref}..#{head_ref}"]
       ok, out, _err = run_cmd(cmd)
       return [] unless ok
-      
       out.split("\n").map(&:strip).reject(&:empty?).uniq
     end
 

--- a/lib/quick_check/cli.rb
+++ b/lib/quick_check/cli.rb
@@ -257,15 +257,25 @@ module QuickCheck
     end
 
     def diff_range_against_base(base)
-      # Prefer the symmetric range base...HEAD if base exists locally,
-      # otherwise fall back to origin/base...HEAD when only remote exists.
-      if local_branch_exists?(base)
-        "#{base}...HEAD"
-      elsif remote_branch_exists?(base)
-        "origin/#{base}...HEAD"
-      else
-        nil
-      end
+      # Use merge-base to find the common ancestor, which correctly handles
+      # rebases and merges by only showing changes unique to the current branch.
+      # This avoids including incoming changes from merges/rebases.
+      merge_base = find_merge_base(base)
+      merge_base ? "#{merge_base}...HEAD" : nil
+    end
+
+    def find_merge_base(base)
+      # Try local branch first, then remote
+      ref = if local_branch_exists?(base)
+              base
+            elsif remote_branch_exists?(base)
+              "origin/#{base}"
+            else
+              return nil
+            end
+
+      ok, out, _err = run_cmd(["git", "merge-base", ref, "HEAD"])
+      ok ? out.to_s.strip : nil
     end
 
     def git_diff_name_only(args)

--- a/lib/quick_check/version.rb
+++ b/lib/quick_check/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module QuickCheck
-  VERSION = "0.1.2"
+  VERSION = "0.1.3"
 end

--- a/spec/quick_check/cli_spec.rb
+++ b/spec/quick_check/cli_spec.rb
@@ -115,11 +115,47 @@ RSpec.describe QuickCheck::CLI do
     expect(status).to eq(0)
   end
 
-  it "uses merge-base to handle rebases correctly" do
+  it "uses first-parent to handle rebases correctly" do
     stubs = base_git_stubs.merge(
       "git show-ref --verify --quiet refs/heads/main" => { success: true },
-      "git merge-base main HEAD" => { stdout: "abc123def456\n" },
-      "git diff --name-only -M -C --diff-filter=ACMR abc123def456...HEAD" => { stdout: "spec/my_feature_spec.rb\n" }
+      "git log --first-parent --name-only --diff-filter=ACMR --format= main..HEAD" => { stdout: "spec/my_feature_spec.rb\n" }
+    )
+
+    status, out, _err = run_cli(["--base", "main", "--dry-run", "--no-unstaged", "--no-staged"], git_outputs: stubs)
+    expect(status).to eq(0)
+    expect(out).to include("bundle exec rspec spec/my_feature_spec.rb")
+  end
+
+  it "prefers upstream branch over base branch when upstream has differences" do
+    stubs = base_git_stubs.merge(
+      "git rev-parse --abbrev-ref --symbolic-full-name feature@{u}" => { stdout: "origin/feature\n" },
+      "git rev-parse --verify --quiet origin/feature" => { success: true },
+      "git rev-list --count origin/feature..HEAD" => { stdout: "5\n" },
+      "git log --first-parent --name-only --diff-filter=ACMR --format= origin/feature..HEAD" => { stdout: "spec/my_local_change_spec.rb\n" }
+    )
+
+    status, out, _err = run_cli(["--base", "main", "--dry-run", "--no-unstaged", "--no-staged"], git_outputs: stubs)
+    expect(status).to eq(0)
+    expect(out).to include("bundle exec rspec spec/my_local_change_spec.rb")
+  end
+
+  it "does not include committed changes when upstream is in sync" do
+    stubs = base_git_stubs.merge(
+      "git rev-parse --abbrev-ref --symbolic-full-name feature@{u}" => { stdout: "origin/feature\n" },
+      "git rev-parse --verify --quiet origin/feature" => { success: true },
+      "git rev-list --count origin/feature..HEAD" => { stdout: "0\n" }
+    )
+
+    status, out, _err = run_cli(["--base", "main", "--dry-run", "--no-unstaged", "--no-staged"], git_outputs: stubs)
+    expect(status).to eq(0)
+    expect(out).to include("No changed/added test files detected.")
+  end
+
+  it "falls back to base branch when no upstream exists" do
+    stubs = base_git_stubs.merge(
+      "git rev-parse --abbrev-ref --symbolic-full-name feature@{u}" => { success: false, exitstatus: 128 },
+      "git show-ref --verify --quiet refs/heads/main" => { success: true },
+      "git log --first-parent --name-only --diff-filter=ACMR --format= main..HEAD" => { stdout: "spec/my_feature_spec.rb\n" }
     )
 
     status, out, _err = run_cli(["--base", "main", "--dry-run", "--no-unstaged", "--no-staged"], git_outputs: stubs)

--- a/spec/quick_check/cli_spec.rb
+++ b/spec/quick_check/cli_spec.rb
@@ -114,4 +114,16 @@ RSpec.describe QuickCheck::CLI do
     expect(out.lines.map(&:strip)).to include("ruby -I test test/models/user_test.rb")
     expect(status).to eq(0)
   end
+
+  it "uses merge-base to handle rebases correctly" do
+    stubs = base_git_stubs.merge(
+      "git show-ref --verify --quiet refs/heads/main" => { success: true },
+      "git merge-base main HEAD" => { stdout: "abc123def456\n" },
+      "git diff --name-only -M -C --diff-filter=ACMR abc123def456...HEAD" => { stdout: "spec/my_feature_spec.rb\n" }
+    )
+
+    status, out, _err = run_cli(["--base", "main", "--dry-run", "--no-unstaged", "--no-staged"], git_outputs: stubs)
+    expect(status).to eq(0)
+    expect(out).to include("bundle exec rspec spec/my_feature_spec.rb")
+  end
 end


### PR DESCRIPTION
Problem:

After rebasing a feature branch, Quick Check would run tests for files that were part of merged commits but not actually changed by the current branch. This led to unnecessary test runs.

Solution:

- Use Git's --first-parent flag to properly handle rebases by only examining direct commits on the branch
- Prefer the upstream tracking branch when available to accurately detect only local changes
- Fall back to the configured base branch if no upstream is set
- Skip committed diff testing when upstream is already in sync with local commits

Changes:

- Added git_upstream_branch() to detect tracking branches
- Added upstream_has_differences?() to check for local commits
- Added git_log_first_parent_files() using --first-parent to exclude merged commits
- Refactored diff_range_against_base() to use the new helper
- Version bump to 0.1.3
- Added comprehensive tests for rebase handling
